### PR TITLE
update to handle private repository with arguments

### DIFF
--- a/linux-install.bash
+++ b/linux-install.bash
@@ -11,7 +11,7 @@
 # License: All Rights Reserved
 # Usage: ./linux-install.bash [OPTIONS] [PACKAGE...]
 # Requirements: curl/wget, gpg, apt/dnf/yum
-# Version: 2.0.0
+# Version: 2.1.0
 ###############################################################################
 
 set -euo pipefail


### PR DESCRIPTION
With no arguments it defaults to installing public repositories.
Adding a single positional argument will also install specified package.
You can prefix extra `--` arguments like private, username, password to enable private repositories & pass in username/password.  Also supports passing in post-exec path to executable for additional setup/configuration.